### PR TITLE
Fetch upstream to local

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.egg-info
+*.pyc

--- a/localdevstorage/__init__.py
+++ b/localdevstorage/__init__.py
@@ -11,4 +11,4 @@ Release logic:
 6. git commit
 7. push to github (to avoid confusion)
 """
-__version__ = '0.4'
+__version__ = '0.5'

--- a/localdevstorage/base.py
+++ b/localdevstorage/base.py
@@ -16,10 +16,13 @@ class BaseStorage(FileSystemStorage):
                 pass
             raise
 
+    def _exists_locally(self, name):
+        return super(BaseStorage, self).exists(name)
+
     def exists(self, name):
-        if super(BaseStorage, self).exists(name):
+        if self._exists_locally(self):
             return True
-        return self._exists(name)
+        return self._exists_upstream(name)
 
     def _write(self, filelike, name):
         dirname = os.path.dirname(self.path(name))
@@ -27,3 +30,9 @@ class BaseStorage(FileSystemStorage):
             os.makedirs(dirname)
         f = open(self.path(name), mode='wb')
         f.write(filelike.read())
+
+    def _fetch_local(self, name, force=False):
+        if self._exists_locally(name) and not force:
+            return
+
+        return self._write(self._get(name), name)

--- a/localdevstorage/base.py
+++ b/localdevstorage/base.py
@@ -29,7 +29,7 @@ class BaseStorage(FileSystemStorage):
         return super(BaseStorage, self).exists(name)
 
     def exists(self, name):
-        if self._exists_locally(self):
+        if self._exists_locally(name):
             return True
         return self._exists_upstream(name)
 

--- a/localdevstorage/base.py
+++ b/localdevstorage/base.py
@@ -8,13 +8,22 @@ class BaseStorage(FileSystemStorage):
         try:
             return super(BaseStorage, self)._open(name, mode)
         except IOError:
+            if 'w' in mode: # if writing, make sure the parent structure exists
+                self._ensure_directory(name)
+
             try:
-                f = self._get(name)
-                self._write(f, name)
-                return super(BaseStorage, self)._open(name, mode)
+                try:
+                    f = self._get(name)
+                except IOError:
+                    # if the underlying file doesn't exist, no matter.
+                    pass
+                else:
+                    # if it does, write the contents locally
+                    self._write(f, name)
+
             except Exception:
                 pass
-            raise
+        return super(BaseStorage, self)._open(name, mode)
 
     def _exists_locally(self, name):
         return super(BaseStorage, self).exists(name)
@@ -24,10 +33,13 @@ class BaseStorage(FileSystemStorage):
             return True
         return self._exists_upstream(name)
 
-    def _write(self, filelike, name):
+    def _ensure_directory(self, name):
         dirname = os.path.dirname(self.path(name))
         if not os.path.exists(dirname):
             os.makedirs(dirname)
+
+    def _write(self, filelike, name):
+        self._ensure_directory(name)
         f = open(self.path(name), mode='wb')
         f.write(filelike.read())
 

--- a/localdevstorage/http.py
+++ b/localdevstorage/http.py
@@ -5,6 +5,8 @@ import requests
 
 from django.core.exceptions import ImproperlyConfigured
 from django.conf import settings
+from django.utils.encoding import filepath_to_uri
+from django.utils.six.moves.urllib.parse import urljoin
 
 from localdevstorage.base import BaseStorage
 
@@ -24,16 +26,19 @@ class HttpStorage(BaseStorage):
             self.session.auth = (username, password)
         super(BaseStorage, self).__init__(location, base_url)
 
-    def _exists(self, name):
+    def _exists_upstream(self, name):
         try:
             response = self.session.head(self._path(name))
             return response.status_code == 200
         except Exception:
             return False
 
+    def _url(self, name):
+        return urljoin('/', filepath_to_uri(name))
+
     def _path(self, name):
         if self.fallback_domain:
-            return urlparse.urljoin(self.fallback_domain, self.url(name))
+            return urlparse.urljoin(self.fallback_domain, self._url(name))
         return self.fallback_url + name
 
     def _get(self, name):

--- a/localdevstorage/sftp.py
+++ b/localdevstorage/sftp.py
@@ -72,7 +72,7 @@ class SftpStorage(BaseStorage):
         except IOError:
             pass
 
-    def _exists(self, name):
+    def _exists_upstream(self, name):
         try:
             f = SFTPStorageFile(name, self, 'rb')
             f.close()

--- a/localdevstorage/tests/http.py
+++ b/localdevstorage/tests/http.py
@@ -1,11 +1,15 @@
-from django.test import TestCase
+from django.conf import settings
+from unittest import TestCase
 
 from localdevstorage.http import HttpStorage
 
+settings.configure(
+    LOCALDEVSTORAGE_HTTP_FALLBACK_DOMAIN='https://github.com/piquadrat/django-localdevstorage/blob/master/localdevstorage/'
+)
 
 class HttpStorageTest(TestCase):
         def setUp(self):
-            self.storage = HttpStorage(fallback_url='https://github.com/piquadrat/django-localdevstorage/blob/master/localdevstorage/')
+            self.storage = HttpStorage(base_url=settings.LOCALDEVSTORAGE_HTTP_FALLBACK_DOMAIN, location='./localdevstorage/')
 
         def test_http_fallback(self):
             self.f = self.storage.open('base.py')


### PR DESCRIPTION
I did 2 things here, but am happy to split them if useful.

1) 
I have a view that is a wrapper over django.views.static.serve.  It expects to find files at the default_storage.base_location, but it returns 404 because it is not files.Storage-aware.  (static.serve checks the local filesystem.)

I wanted to be able to force the file local, so I added a hook `BaseStorage._fetch_local(name)`.

This also bumps to 0.5 because I couldn't see how self.url() would work, so added self._url, and renamed `_exists` internally to `_exists_locally` and `_exists_upstream`.

2)
I have a dev MEDIA_URL of '/media/', but my upstream is to cloudfront, which doesn't have /media/, so that localhost:8000/media/foo.jpg would be cfdomain/foo.jpg.  I then have a local directory for serving MEDIA, /foo/bar/media/.  

BaseStorage.url('foo') was resulting in '/media/foo', but HttpStorage._path expected that to map to the local file system.

This caused the paths to misalign (._exists(name) would never return True).  It doesn't seem reasonable to me to expect that the remote MEDIA_URL-ish thing should map 1-1 to the local MEDIA_ROOT-ish thing.  This may be a simple issue of documentation - I could be misconfiguring the library.

