### PR TITLE
Make localdevstorage compatible with Python 3

### DIFF
--- a/localdevstorage/base.py
+++ b/localdevstorage/base.py
@@ -1,18 +1,22 @@
 import os
-
 from django.core.files.storage import FileSystemStorage
+
+try:
+    FileNotFoundError
+except:
+    FileNotFoundError = IOError
 
 
 class BaseStorage(FileSystemStorage):
     def _open(self, name, mode='rb'):
         try:
             return super(BaseStorage, self)._open(name, mode)
-        except IOError:
+        except FileNotFoundError:
             try:
                 f = self._get(name)
                 self._write(f, name)
                 return super(BaseStorage, self)._open(name, mode)
-            except Exception:
+            except FileNotFoundError:
                 pass
             raise
 

--- a/localdevstorage/sftp.py
+++ b/localdevstorage/sftp.py
@@ -5,7 +5,7 @@
 # License: MIT
 #
 # Modeled on the FTP storage by Rafal Jonca <jonca.rafal@gmail.com>
-
+from __future__ import print_function
 try:
     import ssh
 except ImportError:
@@ -16,9 +16,10 @@ import posixpath
 from django.conf import settings
 from django.core.files.base import File
 try:
-    from cStringIO import StringIO
+    from io import StringIO
 except ImportError:
-    from StringIO import StringIO
+    # Python 2 fallbacks
+    from cStringIO import StringIO
 
 from localdevstorage.base import BaseStorage
 
@@ -51,10 +52,10 @@ class SftpStorage(BaseStorage):
 
         try:
             self._ssh.connect(self._host, **self._params)
-        except ssh.AuthenticationException, e:
+        except ssh.AuthenticationException as e:
             raise
-        except Exception, e:
-            print e
+        except Exception as e:
+            print(e)
 
         if not hasattr(self, '_sftp'):
             self._sftp = self._ssh.open_sftp()


### PR DESCRIPTION
Hey Benjamin,

this PR should make localdevstorage compatible with Python 3.
So far I tested the HTTP backend  manually against Python 2.7 and Python 3.4.

Obviously tox and an extended testsuite would be nice, but I first wanted to check if you are interested in Python 3 compatibility.
